### PR TITLE
Correctly reap docker instances on killTask

### DIFF
--- a/src/toil/batchSystems/mesos/__init__.py
+++ b/src/toil/batchSystems/mesos/__init__.py
@@ -146,6 +146,8 @@ class ResourceRequirement(object):
 ToilJob = namedtuple('ToilJob', (
     # A job ID specific to this batch system implementation
     'jobID',
+    # A jobStoreID related to the job
+    'jobStoreID',
     # What string to display in the mesos UI
     'name',
     # A ResourceRequirement tuple describing the resources needed by this job

--- a/src/toil/batchSystems/mesos/batchSystem.py
+++ b/src/toil/batchSystems/mesos/batchSystem.py
@@ -163,6 +163,7 @@ class MesosBatchSystem(BatchSystemSupport,
         self.checkResourceRequest(jobNode.memory, jobNode.cores, jobNode.disk)
         jobID = next(self.unusedJobID)
         job = ToilJob(jobID=jobID,
+                      jobStoreID=jobNode.jobStoreID,
                       name=str(jobNode),
                       resources=ResourceRequirement(**jobNode._requirements),
                       command=jobNode.command,
@@ -618,7 +619,7 @@ class MesosBatchSystem(BatchSystemSupport,
     @classmethod
     def setOptions(cl, setOption):
         setOption("mesosMasterAddress", None, None, 'localhost:5050')
-        
+
 
 def toMiB(n):
     return n / 1024 / 1024

--- a/src/toil/batchSystems/mesos/executor.py
+++ b/src/toil/batchSystems/mesos/executor.py
@@ -86,11 +86,16 @@ class MesosExecutor(mesos.interface.Executor):
         pid, job_id = self.runningTasks[taskId]
         if self.workerCleanupInfo is not None:
             workflow_id = self.workerCleanupInfo.workflowID
-            docker_kill_command = "docker kill `docker ps -q -f label=job_id={} -f label=workflow_id={}`".format(
+            docker_stop_command = "docker stop `docker ps -q -f label=job_id={} -f label=workflow_id={}`".format(
                 job_id, workflow_id)
-            p = subprocess.Popen(docker_kill_command, shell=True)
+            p = subprocess.Popen(docker_stop_command, shell=True)
             if p.wait() != 0:
                 log.debug("Couldn't kill docker container with job_id {}, workflow_id: {}".format(job_id, workflow_id))
+            else:
+                docker_rm_command = "docker rm `docker ps -q -a -f label=job_id={} -f label=workflow_id={}`".format(
+                    job_id, workflow_id)
+                p = subprocess.Popen(docker_rm_command, shell=True)
+                p.wait()
 
         try:
             pgid = os.getpgid(pid)

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -294,6 +294,9 @@ class Job(JobLikeObject):
         self._rvs = collections.defaultdict(list)
         self._promiseJobStore = None
         self._fileStore = None
+        # This references the parent job wrapper. It is initialised just before
+        # the job is run. It is used to access the start and terminate flags.
+        self.jobGraph = None
 
     def run(self, fileStore):
         """
@@ -1231,7 +1234,10 @@ class Job(JobLikeObject):
     ####################################################
 
     def _run(self, jobGraph, fileStore):
-        return self.run(fileStore)
+        self.jobGraph = jobGraph
+        rv = self.run(fileStore)
+        self.jobGraph = None
+        return rv
 
     @contextmanager
     def _executor(self, jobGraph, stats, fileStore):
@@ -1542,9 +1548,6 @@ class ServiceJob(Job):
         self.service = service
         self.pickledService = None
         self.jobName = service.jobName
-        # This references the parent job wrapper. It is initialised just before
-        # the job is run. It is used to access the start and terminate flags.
-        self.jobGraph = None
 
     @property
     def fileStore(self):

--- a/src/toil/job.py
+++ b/src/toil/job.py
@@ -1234,9 +1234,12 @@ class Job(JobLikeObject):
     ####################################################
 
     def _run(self, jobGraph, fileStore):
+        rv = None
         self.jobGraph = jobGraph
-        rv = self.run(fileStore)
-        self.jobGraph = None
+        try:
+            rv = self.run(fileStore)
+        finally:
+            self.jobGraph = None
         return rv
 
     @contextmanager

--- a/src/toil/lib/docker.py
+++ b/src/toil/lib/docker.py
@@ -145,6 +145,11 @@ def _docker(job,
     except IndexError:
         raise RuntimeError("Couldn't parse Docker's `--name=` option, check parameters: " + str(dockerParameters))
 
+    job_id_label = 'job_id={}'.format(job.jobGraph.jobStoreID)
+    workflow_id_label = 'workflow_id={}'.format(job.fileStore.jobStore.config.workflowID)
+    baseDockerCall.extend(['--label', job_id_label])
+    baseDockerCall.extend(['--label', workflow_id_label])
+
     # Defer the container on-exit action
     if '--rm' in baseDockerCall and defer is None:
         defer = RM


### PR DESCRIPTION
Docker containers are launched via the docker daemon. Therefore,
killing child processes within a process group won't suffice to
effectively reap all the tasks launched by the job.

This change labels docker containers with workflow and job IDs and
kills them appropriately on exit.